### PR TITLE
fix(hooks): src change on useImage are not detected

### DIFF
--- a/.changeset/curly-paws-prove.md
+++ b/.changeset/curly-paws-prove.md
@@ -1,0 +1,5 @@
+---
+"@ode-react-ui/hooks": patch
+---
+
+when src param of useImage change the initial value of the state is not always updated. the fix change the state when the src value change

--- a/packages/hooks/src/useImage/useImage.ts
+++ b/packages/hooks/src/useImage/useImage.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 interface useImageProps {
   src: string;
@@ -11,6 +11,9 @@ export default function useImage({ src, placeholder }: useImageProps) {
   const onError = useCallback(() => {
     setImgSrc(placeholder);
   }, []);
-
+  // Force initial value imgSrc to src. If we use the value returned by useState it is wrong the second time the hook is called
+  useEffect(() => {
+    setImgSrc(src);
+  }, [src]);
   return { imgSrc, onError };
 }


### PR DESCRIPTION
# Description

When an src image was changed , **Image** component was not updated. This error occurs because of **useImage** hook that was initialised with a previous value. The next call to useImage does not change the state value. So i added a **useEffect** to update state in case of **src** param changes.

## Which Package changed?

Please check the name of the package you changed

- [ ] Core
- [ ] Icons
- [ X] Hooks
- [ ] Advanced

## Is Documentation or Configuration changed?

- [ ] Storybook
- [ ] Config

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X ] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

# Checklist:

- [ X] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
