### PR TITLE
[a11y] Set focus to Modal h2 element

### DIFF
--- a/.changeset/proud-deers-nail.md
+++ b/.changeset/proud-deers-nail.md
@@ -1,0 +1,5 @@
+---
+"@ode-react-ui/core": patch
+---
+
+a11y: Set Focus to Modal h2 element (https://docs.deque.com/issue-help/1.0.0/en/focus-modal-none)

--- a/packages/core/src/Modal/ModalHeader.tsx
+++ b/packages/core/src/Modal/ModalHeader.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactNode, useEffect, useRef } from "react";
 
 import { useModalContext } from "./ModalContext";
 
@@ -8,10 +8,15 @@ import { useModalContext } from "./ModalContext";
 const ModalHeader = (props: ModalHeaderProps) => {
   const { onModalClose, children } = props;
   const { ariaLabelId } = useModalContext();
+  const h2Ref = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    h2Ref.current?.focus();
+  }, []);
 
   return (
     <div className="modal-header">
-      <h2 id={ariaLabelId} className="modal-title">
+      <h2 ref={h2Ref} id={ariaLabelId} className="modal-title" tabIndex={-1}>
         {children}
       </h2>
       <button


### PR DESCRIPTION
# Description

After running Axe devtools check on Share Modal, the following issue was raised : https://docs.deque.com/issue-help/1.0.0/en/focus-modal-none

To fix it, we set the focus on Modal h2 element like recommended in the previous link.

## Which Package changed?

Please check the name of the package you changed

- [X] Core
- [ ] Icons
- [ ] Hooks
- [ ] Advanced

## Is Documentation or Configuration changed?

- [ ] Storybook
- [ ] Config

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
