### PR TITLE
Add grow props to DropdownTrigger to stetch or not the button

### DIFF
--- a/.changeset/selfish-cows-draw.md
+++ b/.changeset/selfish-cows-draw.md
@@ -1,0 +1,5 @@
+---
+"@ode-react-ui/core": patch
+---
+
+add grow props to DropdownTrigger to stetch or not the button

--- a/packages/core/src/Dropdown/DropdownTrigger.tsx
+++ b/packages/core/src/Dropdown/DropdownTrigger.tsx
@@ -21,12 +21,19 @@ const DropdownTrigger = forwardRef(
       variant,
       icon,
       size = "lg",
+      grow = false,
       badgeContent,
       ...props
     }: DropdownTriggerProps,
     ref: Ref<HTMLButtonElement>,
   ) => {
-    const classNames = clsx("dropdown-trigger", state, size, variant);
+    const classNames = clsx(
+      "dropdown-trigger",
+      state,
+      size,
+      variant,
+      grow && "flex-grow-1 justify-content-between",
+    );
 
     return (
       <button ref={ref} className={classNames} {...props} type="button">

--- a/packages/core/src/Dropdown/DropdownTriggerProps.ts
+++ b/packages/core/src/Dropdown/DropdownTriggerProps.ts
@@ -26,6 +26,10 @@ export interface DropdownTriggerProps
    * Add a badge
    */
   badgeContent?: string | number;
+  /**
+   * Stretch the dropdown trigger.
+   */
+  grow?: boolean;
 }
 
 export type DropdownTriggerType = React.ReactElement<DropdownTriggerProps>;


### PR DESCRIPTION
# Description

By default the Dropdown Trigger button does not grow to the entire parent element width.
I added a prop to stretch the Dropdown Trigger to the parent element width, following CSS Flex implementation.

## Which Package changed?

Please check the name of the package you changed

- [X] Core
- [ ] Icons
- [ ] Hooks
- [ ] Advanced

## Is Documentation or Configuration changed?

- [ ] Storybook
- [ ] Config

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
