### PR TITLE
Add Xiti load page marker

### DIFF
--- a/.changeset/warm-fireants-draw.md
+++ b/.changeset/warm-fireants-draw.md
@@ -1,0 +1,5 @@
+---
+"@ode-react-ui/core": patch
+---
+
+Add Xiti hook

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,3 +8,4 @@ export * from "./useOdeIcons";
 export * from "./useSession";
 export * from "./useTheme";
 export * from "./useUser";
+export * from "./useXitiTrackPageLoad";

--- a/packages/core/src/useXitiTrackPageLoad/index.ts
+++ b/packages/core/src/useXitiTrackPageLoad/index.ts
@@ -1,0 +1,1 @@
+export { default as useXitiTrackPageLoad } from "./useXitiTrackPageLoad";

--- a/packages/core/src/useXitiTrackPageLoad/useXitiTrackPageLoad.tsx
+++ b/packages/core/src/useXitiTrackPageLoad/useXitiTrackPageLoad.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+
+import { odeServices } from "ode-ts-client";
+
+import { useOdeClient } from "../OdeClientProvider";
+
+/** Apply XiTi tracking (navigation). */
+export default function useXitiTrackPageLoad() {
+  const [xitiStatus, setXitiStatus] = useState<string>("pending");
+  const { currentApp } = useOdeClient();
+
+  useEffect(() => {
+    trackPageLoad();
+  }, []);
+
+  const trackPageLoad = async () => {
+    if (!currentApp) {
+      setXitiStatus("[Xiti] Error, currentApp is not defined.");
+      return;
+    }
+    try {
+      await odeServices
+        .analytics()
+        .trackPageLoad(window.location.pathname, currentApp);
+      console.info(`[Xiti] Success tracking page ${window.location.pathname}`);
+      setXitiStatus(`[Xiti] Success tracking page ${window.location.pathname}`);
+    } catch (e) {
+      console.error("[Xiti] Error Tracking Page Load", e);
+      setXitiStatus(`[Xiti] Error Tracking Page Load: ${e}`);
+    }
+  };
+
+  return { xitiStatus };
+}


### PR DESCRIPTION
# Description

Add Xiti load page marker hook.

The hook just calls the new Xiti Marking Service from ode-ts-client (https://github.com/opendigitaleducation/ode-ts-client/commit/0d489d19905ec119d7797a44f04f6dfce0ce8de0)

JIRA: https://opendigitaleducation.atlassian.net/browse/WB2-20

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [X] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
